### PR TITLE
fix typo in vmit.gemspec

### DIFF
--- a/vmit.gemspec
+++ b/vmit.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency('progressbar')
   s.add_dependency('activesupport')
   s.add_dependency('nokogiri')
-  s.add_dependency('ruby-libvirt"', '>= 0.4')
+  s.add_dependency('ruby-libvirt', '>= 0.4')
 
   s.add_development_dependency('webmock')
 end


### PR DESCRIPTION
there was an extra " after ruby-libvirt string.
